### PR TITLE
Hide "CSP directives" section, if no CSP headers is presented

### DIFF
--- a/assets/javascripts/discourse/templates/headlines/tests.hbs
+++ b/assets/javascripts/discourse/templates/headlines/tests.hbs
@@ -50,27 +50,29 @@
     </span>
   </h3>
 
-  <div class="panel panel--info mt">
-    <div class="panel__heading">{{i18n "headlines.tests.content-security-policy.title"}}</div>
-    <div class="panel__body">
-      <table class="tests-table">
-        {{#each directive in model.cspHeader.directives}}
-          <tr>
-            <td class="headers-name">
-              <span class="test-title">
-                {{ directive.name }}
-              </span>
-            </td>
-            <td>
-              <span class="test-value">
-                {{ directive.value }}
-              </span>
-            </td>
-          </tr>
-        {{/each}}
-      </table>
+  {{#if model.cspHeader.directives.length}}
+    <div class="panel panel--info mt">
+      <div class="panel__heading">{{i18n "headlines.tests.content-security-policy.title"}}</div>
+      <div class="panel__body">
+        <table class="tests-table">
+          {{#each directive in model.cspHeader.directives}}
+            <tr>
+              <td class="headers-name">
+                <span class="test-title">
+                  {{ directive.name }}
+                </span>
+              </td>
+              <td>
+                <span class="test-value">
+                  {{ directive.value }}
+                </span>
+              </td>
+            </tr>
+          {{/each}}
+        </table>
+      </div>
     </div>
-  </div>
+  {{/if}}
 
   <table class="tests-table">
     {{#each test in model.cspHeader.tests}}


### PR DESCRIPTION
In addition to https://github.com/fs/security-headers/pull/27
